### PR TITLE
build(typescript): se cambia compilación a es5

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.travis.yml
+/src
+tsconfig.json
+jest.config.json
+.editorconfig
+.eslint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "und-base-entity",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Base entity for our classes",
   "main": "dist/index.js",
   "scripts": {

--- a/src/BaseEntity.test.ts
+++ b/src/BaseEntity.test.ts
@@ -49,7 +49,7 @@ describe('Test BaseEntity Class', async () => {
         },
         true
       );
-    }).toThrowError(ValueRequiredNotFoundError);
+    }).toThrowError('Attribute lastName is required');
   });
 
   test('Set throw exception in required attribute', () => {
@@ -57,7 +57,7 @@ describe('Test BaseEntity Class', async () => {
       new TestEntity({
         firstName: 'Foo'
       });
-    }).toThrowError(ValueRequiredNotFoundError);
+    }).toThrowError('Attribute lastName is required');
   });
 
   test('Test Serialize data from entity', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es5",
     "module": "commonjs",
     "outDir": "./dist",
     "types": ["reflect-metadata", "jest"],


### PR DESCRIPTION
Se realiza este cambio ya que en los SPA la librería UglifyJs solo funciona para es5.